### PR TITLE
Rename test files to *Bench.php to adhere to PHPBench standard

### DIFF
--- a/tests/AbstractJsonPathBench.php
+++ b/tests/AbstractJsonPathBench.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Supermetrics\JsonPath\Benchmarks\Tests;
 
-abstract class AbstractJsonPathBenchmark
+abstract class AbstractJsonPathBench
 {
     /**
      * @param string $dataset

--- a/tests/GalbarBench.php
+++ b/tests/GalbarBench.php
@@ -6,7 +6,7 @@ namespace Supermetrics\JsonPath\Benchmarks\Tests;
 
 use Supermetrics\JsonPath\Benchmarks\Galbar;
 
-class GalbarBenchmark extends AbstractJsonPathBenchmark
+class GalbarBench extends AbstractJsonPathBench
 {
     /**
      * @var Galbar

--- a/tests/JsonPathPhpExtensionBench.php
+++ b/tests/JsonPathPhpExtensionBench.php
@@ -6,7 +6,7 @@ namespace Supermetrics\JsonPath\Benchmarks\Tests;
 
 use Supermetrics\JsonPath\Benchmarks\JsonPathPhpExtension;
 
-class JsonPathPhpExtensionBenchmark extends AbstractJsonPathBenchmark
+class JsonPathPhpExtensionBench extends AbstractJsonPathBench
 {
     /**
      * @var JsonPathPhpExtension

--- a/tests/NativePhpBench.php
+++ b/tests/NativePhpBench.php
@@ -6,7 +6,7 @@ namespace Supermetrics\JsonPath\Benchmarks\Tests;
 
 use Supermetrics\JsonPath\Benchmarks\NativePhp;
 
-class NativePhpBenchmark extends AbstractJsonPathBenchmark
+class NativePhpBench extends AbstractJsonPathBench
 {
     /**
      * @var NativePhp

--- a/tests/RemorhazBench.php
+++ b/tests/RemorhazBench.php
@@ -9,7 +9,7 @@ use Supermetrics\JsonPath\Benchmarks\Remorhaz;
 /**
  * @Skip
  */
-class RemorhazBenchmark extends AbstractJsonPathBenchmark
+class RemorhazBench extends AbstractJsonPathBench
 {
     /**
      * @var Remorhaz

--- a/tests/SoftCreatrBench.php
+++ b/tests/SoftCreatrBench.php
@@ -6,7 +6,7 @@ namespace Supermetrics\JsonPath\Benchmarks\Tests;
 
 use Supermetrics\JsonPath\Benchmarks\SoftCreatr;
 
-class SoftCreatrBenchmark extends AbstractJsonPathBenchmark
+class SoftCreatrBench extends AbstractJsonPathBench
 {
     /**
      * @var SoftCreatr


### PR DESCRIPTION
Warning when running PHPBench:

```
[WARNING] File "NativePhpBenchmark.php" has been identified as a benchmark file but it does not end with `Bench.php`. This behavior is incorrect and will be fixed in a future version. Set `runner.file_pattern` to `*Bench.php` in `phpbench.json` to avoid this.
```